### PR TITLE
Update 02-linear-models-causal-inf.Rmd

### DIFF
--- a/02-linear-models-causal-inf.Rmd
+++ b/02-linear-models-causal-inf.Rmd
@@ -479,6 +479,7 @@ summary(b4h2)
 :::
 
 ```{r e4h2-3, message = FALSE}
+library(modelr)
 mod_fits <- tibble(weight = seq_range(young_how$weight, 100)) %>% 
   mutate(weight_c = weight - mean(young_how$weight)) %>%
   add_epred_draws(b4h2) %>%

--- a/02-linear-models-causal-inf.Rmd
+++ b/02-linear-models-causal-inf.Rmd
@@ -531,7 +531,7 @@ b4h3 <- brm(height ~ 1 + log_weight_c, data = full_how, family = gaussian,
 summary(b4h3)
 ```
 
-Conditional on the data and the model, the intercept estimate of ` sprintf("%0.1f", summary(b4h3)[["fixed"]]["Intercept", "Estimate"])` represents the predicted average height for an individual with an average log-weight (log-kg). The $\beta$ estimate of ` sprintf("%0.1f", summary(b4h3)[["fixed"]]["log_weight_c", "Estimate"])` represents the average expected increase in height associated with an one-unit increase in weight (log-kg).
+Conditional on the data and the model, the intercept estimate of `r sprintf("%0.1f", summary(b4h3)[["fixed"]]["Intercept", "Estimate"])` represents the predicted average height for an individual with an average log-weight (log-kg). The $\beta$ estimate of `r sprintf("%0.1f", summary(b4h3)[["fixed"]]["log_weight_c", "Estimate"])` represents the average expected increase in height associated with an one-unit increase in weight (log-kg).
 
 :::question
 > (b) Begin with this plot: `plot( height ~ weight , data = Howell1 )`. Then use samples from the quadratic approximate posterior of the model in (a) to superimpose on the plot: (1) the predicted mean height as a function of weight, (2) the 97% interval for the mean, and (3) the 97% interval for predicted heights.


### PR DESCRIPTION
modelr::seq_range() [is used](https://modelr.tidyverse.org/reference/seq_range.html). Not loaded in the tidyverse and [not in tidyr](https://tidyr.tidyverse.org/news/index.html#minor-bug-fixes-and-improvements-0-4-0).